### PR TITLE
[FIX] FIFO cost should be taken from quant or stock move if present t…

### DIFF
--- a/addons/stock_account/models/stock.py
+++ b/addons/stock_account/models/stock.py
@@ -322,7 +322,7 @@ class StockMove(models.Model):
                 'price_unit': price_unit,
             })
         elif qty_to_take_on_candidates > 0:
-            last_fifo_price = new_standard_price or move.product_id.standard_price
+            last_fifo_price = new_standard_price or move.price_unit or move.product_id.standard_price
             negative_stock_value = last_fifo_price * -qty_to_take_on_candidates
             tmp_value += abs(negative_stock_value)
             vals = {


### PR DESCRIPTION
…o avoid issues during RMA delivery and receive with vendors. This also helps use the actual purchase cost / original cost on stock move instead of lagging standard_price on inventory transfers.