### PR TITLE
[FIX] account, base: prevent merging account.account

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -787,6 +787,9 @@ class AccountAccount(models.Model):
             'template': '/account/static/xls/coa_import_template.xlsx'
         }]
 
+    def _merge_method(self, destination, source):
+        raise UserError(_("You cannot merge accounts."))
+
 
 class AccountGroup(models.Model):
     _name = "account.group"

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -667,3 +667,11 @@ class ResPartner(models.Model):
         :return: an array of ir.model.fields for which the user should provide values.
         """
         return []
+
+    def _merge_method(self, destination, source):
+        """
+        Prevent merging partners that are linked to already hashed journal items.
+        """
+        if self.env['account.move.line'].search([('move_id.inalterable_hash', '!=', False), ('partner_id', 'in', source.ids)], limit=1):
+            raise UserError(_('Partners that are used in hashed entries cannot be merged.'))
+        return super()._merge_method(destination, source)

--- a/odoo/addons/base/wizard/base_partner_merge.py
+++ b/odoo/addons/base/wizard/base_partner_merge.py
@@ -322,10 +322,6 @@ class MergePartnerAutomatic(models.TransientModel):
             src_partners = ordered_partners[:-1]
         _logger.info("dst_partner: %s", dst_partner.id)
 
-        # FIXME: is it still required to make and exception for account.move.line since accounting v9.0 ?
-        if extra_checks and 'account.move.line' in self.env and self.env['account.move.line'].sudo().search([('partner_id', 'in', [partner.id for partner in src_partners])]):
-            raise UserError(_("Only the destination contact may be linked to existing Journal Items. Please ask the Administrator if you need to merge several contacts linked to existing Journal Items."))
-
         # Make the company of all related users consistent with destination partner company
         if dst_partner.company_id:
             partner_ids.mapped('user_ids').sudo().write({


### PR DESCRIPTION
Steps to reproduce:

- Enable the merge on account.account in data cleaning APP (in debug)
- Create an invoice with a receivable account = A
- Define a lock  date after the invoice date
- Go to chart of accounts
- Select your receivable = A et receivable = B
- Action = Merge accounts where B is the MASTER

Issue:
Upon revisiting the customer invoice: Notice that the journal items have been updated.

Solution:
We simply prevent ~~the use of a nuclear weapon~~ the merge of `account.account` as there other possibilities less dangerous such as multi-edit + archiving

We also prevent the merge of `res.partner` if this one is used in hashed entries

oe:https://github.com/odoo/enterprise/pull/47053

opw-3389157

closes odoo/odoo#136344

X-original-commit: a40659bcda1a4d635f2caacffb740b001bed9e30
Related: odoo/enterprise#47795

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
