### PR TITLE
[FIX] stock_account: remove AAL when changing qty of the component to 0

### DIFF
--- a/addons/mrp_account/tests/test_analytic_account.py
+++ b/addons/mrp_account/tests/test_analytic_account.py
@@ -288,3 +288,52 @@ class TestAnalyticAccount(TestMrpAnalyticAccount):
         self.assertEqual(len(analytic_account_no_company.line_ids), 1)
         mo_no_company.workorder_ids.unlink()
         self.assertEqual(len(analytic_account_no_company.line_ids), 0)
+
+    def test_update_components_qty_to_0(self):
+        """ Test that the analytic lines are deleted when the quantity of the component is set to 0.
+            Create a Mo with analytic account and a component, confirm and validate it,
+            set the quantity of the component to 0, the analytic lines should be deleted.
+        """
+        component = self.env['product.product'].create({
+            'name': 'Component',
+            'type': 'product',
+            'standard_price': 100,
+        })
+        product = self.env['product.product'].create({
+            'name': 'Product',
+            'type': 'product',
+        })
+        bom = self.env['mrp.bom'].create({
+                'product_tmpl_id': product.product_tmpl_id.id,
+                'product_qty': 1,
+                'product_uom_id': product.uom_id.id,
+                'type': 'normal',
+                'bom_line_ids': [(0, 0, {
+                    'product_id': component.id,
+                    'product_qty': 1,
+                    'product_uom_id': component.uom_id.id,
+                })],
+        })
+        analytic_account = self.env['account.analytic.account'].create({
+            'name': "Test Account",
+            'plan_id': self.analytic_plan.id,
+        })
+        mo_form = Form(self.env['mrp.production'])
+        mo_form.product_id = product
+        mo_form.bom_id = bom
+        mo_form.product_qty = 1.0
+        mo_form.analytic_account_id = analytic_account
+        mo = mo_form.save()
+        mo.action_confirm()
+        self.assertEqual(mo.state, 'confirmed')
+
+        mo_form = Form(mo)
+        mo_form.qty_producing = 1
+        mo = mo_form.save()
+        self.assertEqual(mo.state, 'to_close')
+        mo.button_mark_done()
+        self.assertEqual(mo.state, 'done')
+        self.assertEqual(analytic_account.debit, 100)
+        mo.move_raw_ids[0].quantity_done = 0
+        self.assertEqual(analytic_account.debit, 0)
+        self.assertFalse(analytic_account.line_ids)

--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -415,6 +415,7 @@ class StockMove(models.Model):
         if self.state in ['cancel', 'draft']:
             return False
 
+        amount, unit_amount = 0, 0
         if self.state != 'done':
             unit_amount = self.product_uom._compute_quantity(
                 self.quantity_done, self.product_id.uom_id)
@@ -432,6 +433,9 @@ class StockMove(models.Model):
             amount = sum(self.stock_valuation_layer_ids.mapped('value'))
             unit_amount = - sum(self.stock_valuation_layer_ids.mapped('quantity'))
         if self.analytic_account_line_id:
+            if amount == 0 and unit_amount == 0:
+                self.analytic_account_line_id.unlink()
+                return False
             self.analytic_account_line_id.unit_amount = unit_amount
             self.analytic_account_line_id.amount = amount
             return False


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1” with BoM:
    - Component: "C1", cost: $100
- Create a Manufacturing Order to produce 1 unit of "P1":
    - Set any analytic account
    - Confirm and validate the MO
- An analytic account line is created for $100 of C1.
- Change the quantity of the component to 0.
- Try to save

Problem:
A traceback is triggered, because the `amount` and `unit_amount` variables are used without assignment.

Solution:
Assign “0” value to both variable in the beginning of the function, therefore the analytic account line will be deleted.

opw-3257240

closes odoo/odoo#128449

X-original-commit: b9512a0d10aa3bbc40b7a407b7c693ad21d16fea

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
