### PR TITLE
[FIX] mrp: fix MO qty from BoM

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -695,7 +695,7 @@ class MrpProduction(models.Model):
                 date_planned_finished = date_planned_finished + relativedelta(hours=1)
             production.date_planned_finished = date_planned_finished
 
-    @api.depends('company_id', 'bom_id', 'product_id', 'product_qty', 'product_uom_id', 'location_src_id', 'date_planned_start')
+    @api.depends('company_id', 'bom_id', 'product_id', 'product_qty', 'product_uom_id', 'location_src_id')
     def _compute_move_raw_ids(self):
         for production in self:
             if production.state != 'draft':
@@ -856,7 +856,23 @@ class MrpProduction(models.Model):
             if not vals.get('procurement_group_id'):
                 procurement_group_vals = self._prepare_procurement_group_vals(vals)
                 vals['procurement_group_id'] = self.env["procurement.group"].create(procurement_group_vals).id
-        return super().create(vals_list)
+        res = super().create(vals_list)
+        # Make sure that the date passed in vals_list are taken into account and not modified by a compute
+        for rec, vals in zip(res, vals_list):
+            if (rec.move_raw_ids
+                and rec.move_raw_ids[0].date
+                and vals.get('date_planned_start')
+                and rec.move_raw_ids[0].date != vals['date_planned_start']):
+                rec.move_raw_ids.write({
+                    'date': vals['date_planned_start'],
+                    'date_deadline': vals['date_planned_start']
+                })
+            if (rec.move_finished_ids
+                and rec.move_finished_ids[0].date
+                and vals.get('date_planned_finished')
+                and rec.move_finished_ids[0].date != vals['date_planned_finished']):
+                rec.move_finished_ids.write({'date': vals['date_planned_finished']})
+        return res
 
     def unlink(self):
         self.action_cancel()


### PR DESCRIPTION
In a Manufacturing Order based on a BoM, changing the qty values and then change the scheduled date will reset the qty to the bom ones.

This should not be the case.

Regarding the test, setting the date before the bom_id ensure that the date will be set when we enter the _compute_move_raw_ids.

enterprise: https://github.com/odoo/enterprise/pull/51822

opw-3568943

Part-of: odoo/odoo#143496

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
