### PR TITLE
[FIX][57874] Weird formatting (analytic: limit width of analytic tag to 200px )

### DIFF
--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.scss
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.scss
@@ -33,6 +33,11 @@
         .o_delete {
             padding-left: 4px;
         }
+
+        .o_tag_badge_text {
+            @include o-text-overflow(inline-block);
+            max-width: 200px;
+        }
     }
 
     .analytic_distribution_popup {


### PR DESCRIPTION
Steps to reproduce:
- Activate "Analytic Accounting" in Accounting settings
- Go to Accounting / Configuration / Analytic Accounting / Analytic Accounts
- Create an Analytic Account with a very long name (i.e. +100 chars)
- Go to Expenses
- Create an Expense with the created Analytic Account in the Analytic field The display of the labels in the form view should break because the badge is too long and is taking all the available width.

Solution:
Limit the width of tag badges in "analytic_distribution" widget as it is done in "many2many_tags" widget. https://github.com/odoo/odoo/blob/2f47df6663b65c4f6b6ec61f956c453e97563462/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.scss#L47-L49

opw-3322688

closes odoo/odoo#130235

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
